### PR TITLE
13 small edits to tree structure in split querysh and merge outputpy

### DIFF
--- a/containers/singularity/merge_output.py
+++ b/containers/singularity/merge_output.py
@@ -12,19 +12,19 @@ def concatenate_files(output_base_dir):
                 temp_file.write(file.read())
 
 def main(directory):
-    output_final_dir = os.path.join(directory, 'output_final')
-    base_dirs = [d for d in os.listdir(output_final_dir) if os.path.isdir(os.path.join(output_final_dir, d))]
+    base_dirs = [d for d in os.listdir(directory) if os.path.isdir(os.path.join(directory, d)) and "output" in d]
 
     threads = []
     for base_dir in base_dirs:
-        thread = threading.Thread(target=concatenate_files, args=(os.path.join(output_final_dir, base_dir),))
+        output_final_dir = os.path.join(directory, base_dir, 'output_final')
+        thread = threading.Thread(target=concatenate_files, args=(output_final_dir,))
         thread.start()
         threads.append(thread)
 
     for thread in threads:
         thread.join()
 
-    temp_files = [os.path.join(output_final_dir, base_dir, 'temp.txt') for base_dir in base_dirs]
+    temp_files = [os.path.join(directory, base_dir, 'output_final', 'temp.txt') for base_dir in base_dirs]
     temp_files.sort()
 
     with open('output_all.txt', 'w') as final_file:
@@ -43,4 +43,3 @@ if __name__ == "__main__":
 
     directory = sys.argv[1]
     main(directory)
-

--- a/containers/singularity/merge_output.py
+++ b/containers/singularity/merge_output.py
@@ -4,8 +4,8 @@ import threading
 
 def concatenate_files(output_base_dir):
     temp_filename = os.path.join(output_base_dir, 'temp.txt')
-    files = [f for f in os.listdir(output_base_dir) if f.startswith("output_") and f.endswith(".txt")]
-    files.sort(key=lambda x: int(x.split('_')[1].split('.')[0]))
+    files = [f for f in os.listdir(output_base_dir) if f.startswith("part-")]
+    files.sort(key=lambda x: int(x.split('-')[1]))
     with open(temp_filename, 'w') as temp_file:
         for filename in files:
             with open(os.path.join(output_base_dir, filename), 'r') as file:

--- a/containers/singularity/split_query.sh
+++ b/containers/singularity/split_query.sh
@@ -1,19 +1,17 @@
 #!/bin/bash
 
-# Usage: ./split_query.sh DBFile query.fasta num_segments
-# Example: ./split_query.sh db.fasta my_sequences.fasta 5
+# Usage: ./split_query.sh query.fasta num_segments /path/to/output_dir
+# Example: ./split_query.sh my_sequences.fasta 5 /path/to/output_dir
 
 if [ $# -ne 2 ]; then
-    echo "Usage: $0 DBFile query.fasta num_segments"
+    echo "Usage: $0 query.fasta num_segments /path/to/output_dir"
     exit 1
 fi
 
 DBFILE=$1
 input_file="$2"  
 num_segments="$3" 
-
-output_dir="query_segments"
-mkdir -p "$output_dir"
+output_dir="$4"
 
 total_sequences=$(grep -c '^>' "$input_file")
 
@@ -36,8 +34,4 @@ awk -v num_seqs="$sequences_per_segment" -v num_segments="$num_segments" '
 
 echo "$num_segments segments made"
 echo "Segments saved in the '$output_dir' directory."
-
-for segment_file in "$output_dir"/*.fasta; do
-    ./run_spark_jobs.sh $DBFILE $segment_file
-done
 


### PR DESCRIPTION
The following changes were made:

Edits to split_query.sh: 

  - Make output_dir (line 15) an program argument
  - Remove lines 40 to 42

Edits to merge_output.py: 

  - Line 15 —> don’t append “output_final” to directory here yet, just list all output directories under “directory”. You can check if the name contains “output”
  - Append “output_final” in line 20, because each SparkLeBLAST output directory will include an “output_final” subdirectory